### PR TITLE
URL-encode crumb for Yahoo queries

### DIFF
--- a/src/com/moneydance/modules/features/yahooqt/YahooConnection.java
+++ b/src/com/moneydance/modules/features/yahooqt/YahooConnection.java
@@ -232,7 +232,7 @@ public class YahooConnection extends BaseConnection {
     urlStr.append("&f=sl1d1t1c1ohgv"); // format of each line
     urlStr.append("&e=.csv");          // response format
     urlStr.append("&crumb=");       // crumble
-    urlStr.append(crumble);
+    urlStr.append(URLEncoder.encode(crumble, N12EStockQuotes.URL_ENC));
     
     boolean foundRate = false;
     Exception error = null;
@@ -360,7 +360,7 @@ public class YahooConnection extends BaseConnection {
     result.append("&interval=1d");  // interval
     result.append("&events=history"); // history
     result.append("&crumb=");       // crumble
-    result.append(crumble);
+    result.append(URLEncoder.encode(crumble, N12EStockQuotes.URL_ENC));
     
     return result.toString();
   }


### PR DESCRIPTION
I am seeing these exceptions:
```
yahoo: set/updated cookie and/or crumble in 0.715 seconds
Importing history from URL: https://query1.finance.yahoo.com/v7/finance/download/MSFT?period1=1659024000&period2=1659283200&interval=1d&events=history&crumb=6.g\u002F8LIFVSx
opening connection with no proxy to https://query1.finance.yahoo.com/v7/finance/download/MSFT?period1=1659024000&period2=1659283200&interval=1d&events=history&crumb=6.g\u002F8LIFVSx
connecting to: https://query1.finance.yahoo.com/v7/finance/download/MSFT?period1=1659024000&period2=1659283200&interval=1d&events=history&crumb=6.g\u002F8LIFVSx with method: GET proxy: null
java.net.URISyntaxException: Illegal character in query at index 132: https://query1.finance.yahoo.com/v7/finance/download/MSFT?period1=1659024000&period2=1659283200&interval=1d&events=history&crumb=6.g\u002F8LIFVSx
	at java.base/java.net.URI$Parser.fail(Unknown Source)
	at java.base/java.net.URI$Parser.checkChars(Unknown Source)
	at java.base/java.net.URI$Parser.parseHierarchical(Unknown Source)
	at java.base/java.net.URI$Parser.parse(Unknown Source)
	at java.base/java.net.URI.<init>(Unknown Source)
	at java.base/java.net.URL.toURI(Unknown Source)
	at com.moneydance.apps.md.controller.olb.HTTPURLConnectionHelper.urlToURI(HTTPURLConnectionHelper.java:300)
	at com.moneydance.apps.md.controller.olb.HTTPURLConnectionHelper.getURI(HTTPURLConnectionHelper.java:295)
	at com.moneydance.apps.md.controller.olb.HTTPURLConnectionHelper.addCookiesToRequestHeaders(HTTPURLConnectionHelper.java:336)
	at com.moneydance.apps.md.controller.olb.HTTPURLConnectionHelper.beginResponse(HTTPURLConnectionHelper.java:670)
	at com.moneydance.apps.md.controller.olb.HTTPURLConnectionHelper.getResponseCode(HTTPURLConnectionHelper.java:133)
	at com.moneydance.apps.md.controller.olb.HttpsURLConnectionImpl.getResponseCode(HttpsURLConnectionImpl.java:93)
	at com.moneydance.modules.features.yahooqt.SnapshotImporterFromURL.getInputStream(SnapshotImporterFromURL.java:75)
	at com.moneydance.modules.features.yahooqt.SnapshotImporter.importData(SnapshotImporter.java:280)
	at com.moneydance.modules.features.yahooqt.YahooConnection.updateSecurity(YahooConnection.java:317)
	at com.moneydance.modules.features.yahooqt.BaseConnection.updateSecurities(BaseConnection.java:124)
	at com.moneydance.modules.features.yahooqt.YahooConnection.updateSecurities(YahooConnection.java:282)
	at com.moneydance.modules.features.yahooqt.DownloadTask.downloadPrices(DownloadTask.java:211)
	at com.moneydance.modules.features.yahooqt.DownloadTask.call(DownloadTask.java:123)
	at com.moneydance.modules.features.yahooqt.DownloadTask.call(DownloadTask.java:21)
	at java.base/java.util.concurrent.FutureTask.run(Unknown Source)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source)
	at java.base/java.lang.Thread.run(Unknown Source)
```

The `\u002F`, I assume is the `/` character and that is causing an exception.  I cannot build the code due to missing dependencies, so I cannot verify that this will resolve it. However, we should not have an exception thrown because of `/` in part of the URI.

I cannot tell if the crumb itself is bad or not, but I cannot pull quotes due to this issue.